### PR TITLE
Write ignores to stderr

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -122,7 +122,7 @@ func (builder *SitemapBuilder) procesSite(site *domain.Site, approvedLink chan<-
 		if translatedAsset := translateLink(site.Url, asset); translatedAsset != "" {
 			site.Assets = append(site.Assets, translatedAsset)
 		} else {
-			fmt.Println("Ignoring asset", asset, "which translated to", translatedAsset)
+			println("Ignoring asset", asset, "which translated to", translatedAsset)
 		}
 	}
 


### PR DESCRIPTION
This PR writes ignores to stderr..

If you use `docker run mkboudreau/sitemap -f json someurl > mysitemaps.jsonl` you could easily generate a big JSONL file for multiple sites. However, the errors are not properly printed to stderr which makes the output cluttered. If I understand correctly, `println` in Go automagically writes to stderr.